### PR TITLE
refactor!: Improve time zone interface, make self-contained.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "date-rs"
-version = "0.1.8"
+version = "1.0.0"
 edition = "2021"
 authors = ["Luke Sneeringer <luke@sneeringer.com>"]
 description = "Gregorian calendar date"
 keywords = ["date", "time"]
 categories = ["date-and-time"]
-rust-version = "1.70"
+rust-version = "1.73"
 license = "MIT"
 repository = "https://github.com/lukesneeringer/date-rs"
 documentation = "https://docs.rs/date_rs"
@@ -21,11 +21,11 @@ exclude = [
 name = "date"
 
 [dependencies]
-anyhow = { version = "1", optional = true }
 diesel = { version = "2", optional = true }
 serde = { version = "1", optional = true }
 strptime = { version = "0.2" }
 tzdb = { version = "0.6", optional = true, features = ["local"] }
+tz-rs = { version = "0.6", optional = true }
 
 [dev-dependencies]
 assert2 = "0.3"
@@ -36,4 +36,4 @@ serde_json = { version = "1" }
 default = ["serde"]
 diesel-pg = ["dep:diesel", "diesel/postgres"]
 easter = []
-tzdb = ["dep:anyhow", "dep:tzdb"]
+tz = ["dep:tz-rs", "dep:tzdb"]

--- a/src/db.rs
+++ b/src/db.rs
@@ -10,8 +10,8 @@ use diesel::serialize::Result as SerializeResult;
 use diesel::serialize::ToSql;
 use diesel::sql_types;
 
+use crate::interval::DateInterval;
 use crate::Date;
-use crate::DateInterval;
 
 impl ToSql<sql_types::Date, Pg> for Date {
   fn to_sql<'se>(&'se self, out: &mut Output<'se, '_, Pg>) -> SerializeResult {

--- a/src/interval.rs
+++ b/src/interval.rs
@@ -18,7 +18,7 @@ use crate::Date;
 #[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
 #[repr(transparent)]
 pub struct DateInterval {
-  pub days: i32, // FIXME: Make private in 1.0.
+  days: i32,
 }
 
 impl DateInterval {
@@ -101,7 +101,7 @@ impl Sub<Date> for Date {
 ///
 /// ```
 /// use date::date;
-/// use date::MonthInterval;
+/// use date::interval::MonthInterval;
 ///
 /// assert_eq!(date! { 2012-04-21 } + MonthInterval::new(3), date! { 2012-07-21 });
 /// assert_eq!(date! { 2021-12-31 } + MonthInterval::new(2), date! { 2022-02-28 });


### PR DESCRIPTION
This PR cleans up how time zones works, enables several tz-methods to be newly `const`, and re-exports commonly needed stuff from the `tz-rs` and `tzdb` crates.